### PR TITLE
Bug 201 - Number of web instances is inconsistent

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -39,12 +39,6 @@
             },
             "defaultValue": ""
         },
-        "numberOfWebInstances": {
-            "type": "int",
-            "defaultValue": 2,
-            "minValue": 2,
-            "maxValue": 5
-        },
         "useExistingKek": {
             "type": "string",
             "defaultValue": "kek",
@@ -409,7 +403,8 @@
                 "staticIPWEBStart": 5,
                 "ipAddresses": [
                     { "IpAddress": "10.200.2.5" },
-                    { "IpAddress": "10.200.2.6" }
+                    { "IpAddress": "10.200.2.6" },
+					{ "IpAddress": "10.200.2.7" }
                 ]
             },
             "mgt": {
@@ -1173,8 +1168,8 @@
                     "mgtPublicIPName": {
                         "value": "[variables('resourceNames').publicIPs.mgt]"
                     },
-                    "numberOfWebInstances": {
-                      "value": "[variables('numberOfWebInstances')]"
+                    "ipAddressArray": {
+                      "value": "[variables('vmSettings').web.ipAddresses]"
                     },
                     "webNICName": {
                         "value": "[variables('resourceNames').nics.web]"
@@ -1225,7 +1220,7 @@
                         "value": "[variables('resourceNames').gatewaySkuName]"
                     },
                     "capacity": {
-                        "value": 2
+                        "value": "[variables('numberOfWebInstances')]"
                     },
                     "backendIpsForPathRuleWEB": {
                         "value": "[variables('vmSettings').web.ipAddresses]"

--- a/nestedtemplates/networkInterfaces.json
+++ b/nestedtemplates/networkInterfaces.json
@@ -5,12 +5,6 @@
     "location": {
       "type": "string"
     },
-    "numberOfWebInstances": {
-        "type": "int",
-        "defaultValue": 2,
-        "minValue": 2,
-        "maxValue": 5
-    },
     "webNICName": {
         "type": "string"
     },
@@ -91,6 +85,9 @@
     },
     "mgtPublicIPName": {
       "type": "string"
+    },
+	"ipAddressArray": {
+      "type": "array"
     }
   },
   "resources": [
@@ -236,7 +233,7 @@
         },
         "copy": {
             "name": "nicLoopDEL",
-            "count": "[parameters('numberOfWebInstances')]"
+            "count": "[length(parameters('ipAddressArray'))]"
         },
         "dependsOn": [],
         "properties": {
@@ -244,7 +241,7 @@
                 "name": "ipconfig1",
                 "properties": {
                     "privateIPAllocationMethod": "Static",
-                    "privateIPAddress": "[concat(split(parameters('webSubnetAddressRange'), '0/')[0], add(copyindex(), parameters('staticIPWEBStart')))]",
+                    "privateIPAddress": "[parameters('ipAddressArray')[copyindex('nicLoopDEL')].IpAddress]",
                     "subnet": {
                         "id": "[parameters('subnetRef')]"
                     }


### PR DESCRIPTION
1 - Removed "numberOfWebInstances" parameter from main template.
2 - Added "ipAddressArray", these number of IPs will be considered as
"numberOfWebInstances".
3 - In "networkInterfaces.json", the privateIPAddress will be assigned
by looping on this array.
"privateIPAddress":
"[parameters('ipAddressArray')[copyindex('nicLoopDEL')].IpAddress]"
4 - Capacity for Application Gateway is changed to "numberOfWebInstances