### PR TITLE
Fixed double-hashing of AADClientSecret variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This Azure Blueprint solution is comprised of JSON configuration files and Power
 
 3. Click the button below, sign into the Azure portal, enter the required ARM template parameters, and click **Purchase**. [Read more about deployment.](#deployment)
 
-	[![Deploy to Azure](http://azuredeploy.net/AzureGov.png)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Ffedramp-iaas-webapp%2Fmaster%2Fazuredeploy.json)
+	[![Deploy to Azure](http://azuredeploy.net/AzureGov.png)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmik-e-kim%2Ffedramp-iaas-webapp%2Fmaster%2Fazuredeploy.json)
 
 ### PRE-DEPLOYMENT
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -2237,8 +2237,7 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2015-01-01",
             "dependsOn": [
-                  "ConfigureAutomationSchedules",
-                  "[concat('ConfigurationVMEncryption-', variables('vmNamesArrayAD').VMs[copyIndex()].Name)]"
+                  "ConfigureAutomationSchedules"
             ],
             "copy": {
                 "name": "encryptionSQLMGTLoop",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -309,21 +309,21 @@
             "metadata": {
                 "description": "Linked Templates base url"
             },
-            "defaultValue": "https://raw.githubusercontent.com/Azure/fedramp-iaas-webapp/master/nestedtemplates"
+            "defaultValue": "https://raw.githubusercontent.com/mik-e-kim/fedramp-iaas-webapp/master/nestedtemplates"
         },
         "dscBaseUrl": {
             "type": "string",
             "metadata": {
                 "description": "DSC Scripts base url"
             },
-            "defaultValue": "https://raw.githubusercontent.com/Azure/fedramp-iaas-webapp/master/DSC"
+            "defaultValue": "https://raw.githubusercontent.com/mik-e-kim/fedramp-iaas-webapp/master/DSC"
         },
         "scriptsBaseUrl": {
             "type": "string",
             "metadata": {
                 "description": "DSC Scripts base url"
             },
-            "defaultValue": "https://raw.githubusercontent.com/Azure/fedramp-iaas-webapp/master/custom-scripts"
+            "defaultValue": "https://raw.githubusercontent.com/mik-e-kim/fedramp-iaas-webapp/master/custom-scripts"
         },
         "sqlServerVersion": {
             "type": "string",
@@ -2161,7 +2161,8 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2015-01-01",
             "dependsOn": [
-                  "ConfigureAutomationSchedules"
+                  "ConfigureAutomationSchedules",
+                  "[concat('ConfigurationVMEncryption-', variables('resourceNames').vms.web, copyindex())]"
             ],
             "copy": {
                 "name": "encryptionSQLMGTLoop",
@@ -2236,7 +2237,8 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2015-01-01",
             "dependsOn": [
-                  "ConfigureAutomationSchedules"
+                  "ConfigureAutomationSchedules",
+                  "[concat('ConfigurationVMEncryption-', variables('vmNamesArrayAD').VMs[copyIndex()].Name)]"
             ],
             "copy": {
                 "name": "encryptionSQLMGTLoop",

--- a/predeploy/Orchestration_InitialSetup.ps1
+++ b/predeploy/Orchestration_InitialSetup.ps1
@@ -371,8 +371,7 @@ function orchestration {
 
 		Write-Host "Set Azure Key Vault Access Policy. Set Application Client Secret in Key Vault: $keyVaultName";
 		$key = Add-AzureKeyVaultKey -VaultName $keyVaultName -Name 'aadClientSecret' -Destination 'Software'
-		$aadClientSecretSecureString = ConvertTo-SecureString $aadClientSecret -AsPlainText -Force
-		$secret = Set-AzureKeyVaultSecret -VaultName $keyVaultName -Name 'aadClientSecret' -SecretValue $aadClientSecretSecureString
+		$secret = Set-AzureKeyVaultSecret -VaultName $keyVaultName -Name 'aadClientSecret' -SecretValue $aadClientSecret
 
 		Write-Host "Set Azure Key Vault Access Policy. Set Key Encryption URL in Key Vault: $keyVaultName";
 		$key = Add-AzureKeyVaultKey -VaultName $keyVaultName -Name 'keyEncryptionKeyURL' -Destination 'Software'


### PR DESCRIPTION
Previous deployment script had AADClientSecret stored as a string and converted downstream into a securestring captured in a different variable. 

The script was double-hashing the AADClientSecret variable, leading to key vault access issues due to mismatched secret(s). 

This fix removes the unnecessary double-hashing of AADClientSecret and correctly passes in the SecureString into the keyvault. Also captures the correct client secret for use in automated ARM deployments.