### PR TITLE
Fixed double-hashing of AADClientSecret

### DIFF
--- a/predeploy/Orchestration_InitialSetup.ps1
+++ b/predeploy/Orchestration_InitialSetup.ps1
@@ -371,8 +371,7 @@ function orchestration {
 
 		Write-Host "Set Azure Key Vault Access Policy. Set Application Client Secret in Key Vault: $keyVaultName";
 		$key = Add-AzureKeyVaultKey -VaultName $keyVaultName -Name 'aadClientSecret' -Destination 'Software'
-		$aadClientSecretSecureString = ConvertTo-SecureString $aadClientSecret -AsPlainText -Force
-		$secret = Set-AzureKeyVaultSecret -VaultName $keyVaultName -Name 'aadClientSecret' -SecretValue $aadClientSecretSecureString
+		$secret = Set-AzureKeyVaultSecret -VaultName $keyVaultName -Name 'aadClientSecret' -SecretValue $aadClientSecret
 
 		Write-Host "Set Azure Key Vault Access Policy. Set Key Encryption URL in Key Vault: $keyVaultName";
 		$key = Add-AzureKeyVaultKey -VaultName $keyVaultName -Name 'keyEncryptionKeyURL' -Destination 'Software'


### PR DESCRIPTION
Original pre-deployment script had the AADClientSecret stored as a string, as previous versions of the PowerShell ARM module did not require it to be a securestring parameter. 

Updated the pre-deployment script to generate an AADClientSecret as a securestring and cleaned up older code/logic that resulted in the double-hashing of that parameter.