### PR TITLE
Nesting Encryption of AD DC VM Set

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -2237,7 +2237,8 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2015-01-01",
             "dependsOn": [
-                  "ConfigureAutomationSchedules"
+                  "ConfigureAutomationSchedules",
+		  "ConfigurationVMEncryption-AZ-PDC-VM"
             ],
             "copy": {
                 "name": "encryptionSQLMGTLoop",


### PR DESCRIPTION
Updating the primary template so that VM encryption steps are gated. 

Web VM set (2) encrypts first, followed by DC VM set (2), and ending with SQL/MGT VM set (4).

This will limit max simultaneous key vault calls to 4.