### PR TITLE
Update New-RandomPassword Function

### DIFF
--- a/predeploy/Orchestration_InitialSetup.ps1
+++ b/predeploy/Orchestration_InitialSetup.ps1
@@ -184,15 +184,19 @@ function checkPasswords {
 ########################################################################################################################
 # GENERATE RANDOM PASSWORD FOR CERT FUNCTION
 ########################################################################################################################
-Function New-RandomPassword() {
+Function New-AlphaNumericPassword () {
     [CmdletBinding()]
     param(
         [int]$Length = 14
     )
-    $ascii=$NULL;For ($a=33;$a -le 126;$a++) {$ascii+=,[char][byte]$a}
-    for ($loop=1; $loop -le $length; $loop++) {
-        $RandomPassword+=($ascii | GET-RANDOM)
-    }
+        $ascii=$NULL
+        $AlphaNumeric = @(48..57;65..90;97..122)
+        Foreach ($Alpha in $AlphaNumeric) {
+            $ascii+=,[char][byte]$Alpha
+            }
+        for ($loop=1; $loop -le $length; $loop++) {
+            $RandomPassword+=($ascii | GET-RANDOM)
+        }
     return $RandomPassword
 }
 
@@ -326,7 +330,7 @@ function orchestration {
 			$keyEncryptionKeyUrl = $kek.Key.Kid;
 		}
 
-		$certPassword = New-RandomPassword
+		$certPassword = New-AlphaNumericPassword
 		$secureCertPassword = ConvertTo-SecureString $certPassword -AsPlainText -Force
 		Generate-Cert -certPassword $secureCertPassword -domain $domain
 		$certificate = Get-Content -Path ".\cert.txt" | Out-String


### PR DESCRIPTION
This function previously included all ASCII characters that were alphanumeric or special characters. 
Revised the function to only call from a limited set of 62 characters: 26 lowercase letters, 26 uppercase letters, and 10 numerals. 
Function has been renamed to reflect it only generates alphanumeric passwords.