### PR TITLE
Nesting VM Encryption Deployment Templates

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -2238,7 +2238,8 @@
             "apiVersion": "2015-01-01",
             "dependsOn": [
                   "ConfigureAutomationSchedules",
-		  "ConfigurationVMEncryption-AZ-PDC-VM"
+		  "ConfigurationVMEncryption-AZ-PDC-VM",
+		  "ConfigurationVMEncryption-AZ-BDC-VM"
             ],
             "copy": {
                 "name": "encryptionSQLMGTLoop",


### PR DESCRIPTION
Updating primary template for further isolating and gating VM encryption steps. 

Now set to deploy in the following order:
- Web VM Set (2)
- DC VM Set (2)
- SQL + MGT VM set (4)

Will deploy as 2, 2, 4 -- following VM encryption templates will not kick off until previous dependencies have completed. 

Have tested repeatedly for a week with improved success frequency/fewer failed deployments.