### PR TITLE
Update Orchestration_InitialSetup.ps1

### DIFF
--- a/predeploy/Orchestration_InitialSetup.ps1
+++ b/predeploy/Orchestration_InitialSetup.ps1
@@ -308,6 +308,11 @@ function orchestration {
 
 			Write-Host "Creating new AAD application ($aadAppName)" -ForegroundColor Yellow;
 			$ADApp = New-AzureRmADApplication -DisplayName $aadAppName -HomePage $defaultHomePage -IdentifierUris $identifierUri  -StartDate $now -EndDate $oneYearFromNow -Password $aadClientSecret;
+			
+		# sleep function, waits for 30 seconds to give Azure time to create the app to avoid error message:
+		#    "The appId 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' of the service principal does not reference a valid application object."
+		Start-Sleep -s 30
+			
 			$servicePrincipal = New-AzureRmADServicePrincipal -ApplicationId $ADApp.ApplicationId;
 			$SvcPrincipals = (Get-AzureRmADServicePrincipal -SearchString $aadAppName);
 			if(-not $SvcPrincipals)


### PR DESCRIPTION
Added a sleep function for 30 seconds right after line 310 because of consistent errors in running Orchestration_InitialSetup.ps1 where it would fail with the error message "The appId 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' of the service principal does not reference a valid application object" because Azure had not yet completed creation of AAD application before script was trying to get the returned appID 

# sleep function, waits for 30 seconds to give Azure time to create the app to avoid error message:
#    "The appId 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' of the service principal does not reference a valid application object."
Start-Sleep -s 30